### PR TITLE
Add support for no notch input and create multiline input

### DIFF
--- a/src/components/MultilineInput/MultilineInput.stories.tsx
+++ b/src/components/MultilineInput/MultilineInput.stories.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from "react";
 import { Meta } from "@storybook/react/types-6-0";
 import { Story } from "@storybook/react";
-import TextInput from "./TextInput";
+import MultilineInput from "./MultilineInput";
 import { OutlinedInputProps } from "@material-ui/core/OutlinedInput";
 
 export default {
-  title: "Components/Inputs/TextInput",
-  component: TextInput,
+  title: "Components/Inputs/MultilineInput",
+  component: MultilineInput,
 } as Meta;
 
 const Template: Story<OutlinedInputProps> = (args) => {
@@ -20,18 +20,11 @@ const Template: Story<OutlinedInputProps> = (args) => {
 
   return (
     <>
-      <TextInput {...args} onChange={onChange} />
+      <MultilineInput {...args} onChange={onChange} />
       <p>{val}</p>
     </>
   );
 };
 
-export const Notched = Template.bind({});
-Notched.args = {
-  notched: true,
-  label: "This is a label",
-  placeholder: "Hey this is an input",
-};
-
-export const NoNotch = Template.bind({});
-NoNotch.args = { placeholder: "Hey this is an input" };
+export const Primary = Template.bind({});
+Primary.args = { placeholder: "Update...", multiline: true, rows: 3 };

--- a/src/components/MultilineInput/MultilineInput.styles.ts
+++ b/src/components/MultilineInput/MultilineInput.styles.ts
@@ -1,0 +1,29 @@
+export const baseStyles = {
+  root: {
+    marginBottom: "16px",
+    width: "200px",
+    color: "#8c8c8c",
+    alignItems: "normal",
+    "& .MuiOutlinedInput-notchedOutline": {
+      borderColor: "#333333",
+    },
+    "&:hover .MuiOutlinedInput-notchedOutline": {
+      borderColor: "#333333",
+    },
+    "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+      borderColor: "#333333",
+    },
+  },
+  notchedOutline: {
+    "& > legend": {
+      visibility: "visible",
+      fontWeight: "600",
+      fontSize: "10px",
+      lineHeight: "16px",
+      color: "#8C8C8C",
+    },
+  },
+  multiline: {
+    padding: "14px 10px",
+  },
+};

--- a/src/components/MultilineInput/MultilineInput.tsx
+++ b/src/components/MultilineInput/MultilineInput.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+import { OutlinedInput } from "@material-ui/core";
+import { OutlinedInputProps } from "@material-ui/core/OutlinedInput";
+import { withStyles } from "@material-ui/core/styles";
+
+import { baseStyles } from "./MultilineInput.styles";
+
+const BaseInput = withStyles(baseStyles)(OutlinedInput);
+
+const MultilineInput = (props: OutlinedInputProps) => {
+  const inputProps = { ...props };
+  if (props.rows) {
+    inputProps.style = {
+      ...inputProps.style,
+      height: `${44 * Number(props.rows)}px`,
+    };
+  }
+  return <BaseInput {...inputProps} />;
+};
+
+export default MultilineInput;

--- a/src/components/MultilineInput/index.ts
+++ b/src/components/MultilineInput/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MultilineInput";

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -26,5 +26,12 @@ const Template: Story<OutlinedInputProps> = (args) => {
   );
 };
 
-export const Primary = Template.bind({});
-Primary.args = { label: "Hey", placeholder: "Hey this is an input" };
+export const Notched = Template.bind({});
+Notched.args = {
+  notched: true,
+  label: "This is a label",
+  placeholder: "Hey this is an input",
+};
+
+export const NoNotch = Template.bind({});
+NoNotch.args = { placeholder: "Hey this is an input" };

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -9,7 +9,7 @@ import { baseStyles } from "./TextInput.styles";
 const BaseInput = withStyles(baseStyles)(OutlinedInput);
 
 const TextInput = (props: OutlinedInputProps) => {
-  return <BaseInput notched {...props} />;
+  return <BaseInput {...props} />;
 };
 
 export default TextInput;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 import Button from "./components/Button";
 import TextInput from "./components/TextInput";
-import ToggleButton from "./components/ToggleButton"
-export { Button, TextInput, ToggleButton };
+import ToggleButton from "./components/ToggleButton";
+import MultilineInput from "./components/MultilineInput";
+
+export { Button, TextInput, ToggleButton, MultilineInput };


### PR DESCRIPTION
<img width="345" alt="Screen Shot 2021-08-19 at 4 53 05 PM" src="https://user-images.githubusercontent.com/13020292/130142417-02059390-b3ac-47a8-bbe3-d59ef6132032.png">

<img width="598" alt="Screen Shot 2021-08-19 at 4 53 00 PM" src="https://user-images.githubusercontent.com/13020292/130142595-e976a536-b27e-4ec3-aa7b-04a4f4204c2d.png">


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.3--canary.5.fb3ed656735a4e3931d73726b63d10d6779dca6a.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install citizen-components@1.0.3--canary.5.fb3ed656735a4e3931d73726b63d10d6779dca6a.0
  # or 
  yarn add citizen-components@1.0.3--canary.5.fb3ed656735a4e3931d73726b63d10d6779dca6a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
