### PR TITLE
Changed Text Input Colors to be closer to design

### DIFF
--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -21,7 +21,6 @@ const Template: Story<OutlinedInputProps> = (args) => {
   return (
     <>
       <TextInput {...args} onChange={onChange} />
-      <p>{val}</p>
     </>
   );
 };

--- a/src/components/TextInput/TextInput.styles.ts
+++ b/src/components/TextInput/TextInput.styles.ts
@@ -13,6 +13,25 @@ export const baseStyles = {
     "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
       borderColor: "#333333",
     },
+    fontFamily: [
+      '-apple-system',
+      'BlinkMacSystemFont',
+      'sans-serif',
+    ].join(','),
+    fontWeight: 500,
+  },
+  input: {
+    '&::placeholder': {
+      textOverflow: 'ellipsis !important',
+      color: '#8c8c8c',
+      opacity: 100,
+    },
+    fontSize: "12px",
+    fontFamily: [
+      '-apple-system',
+      'BlinkMacSystemFont',
+      'sans-serif',
+    ].join(','),
   },
   notchedOutline: {
     "& > legend": {
@@ -21,6 +40,7 @@ export const baseStyles = {
       fontSize: "10px",
       lineHeight: "16px",
       color: "#8C8C8C",
+      paddingBottom: 5,
     },
   },
 };


### PR DESCRIPTION
Will probably eventually need this all in a theme...
Original:
<img width="319" alt="Screen Shot 2021-08-26 at 2 29 23 PM" src="https://user-images.githubusercontent.com/19499941/131024400-a2cc5204-da03-4499-830c-c1f03921507e.png">
New:
<img width="358" alt="Screen Shot 2021-08-26 at 2 29 16 PM" src="https://user-images.githubusercontent.com/19499941/131024462-41ade2ff-57c7-491d-9250-3c15bc5edef1.png">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.7--canary.9.4d2e5d636690a834ae773fb7effed98db6dd5255.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install citizen-components@1.0.7--canary.9.4d2e5d636690a834ae773fb7effed98db6dd5255.0
  # or 
  yarn add citizen-components@1.0.7--canary.9.4d2e5d636690a834ae773fb7effed98db6dd5255.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
