### PR TITLE
support nested text with inline

### DIFF
--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -23,8 +23,41 @@ const Template: Story<TextProps> = (args) => {
   );
 };
 
+const Template2: Story<TextProps> = (args) => {
+  return (
+    <div style={{ width: "100%" }}>
+      <Text
+        size={args.size}
+        color={args.color}
+        weight={args.weight}
+        align={args.align}
+      >
+        <Text
+          size={args.size}
+          color="#FF0000"
+          weight={args.weight}
+          align={args.align}
+          style={{ paddingRight: "8px" }}
+        >
+          S1
+        </Text>
+        {args.children}
+      </Text>
+    </div>
+  );
+};
+
 export const PrimarySmallSemibold = Template.bind({});
 PrimarySmallSemibold.args = {
+  size: "small",
+  color: "primary",
+  children: "Hey this is some text",
+  weight: "normal",
+  align: "inherit",
+};
+
+export const NestedText = Template2.bind({});
+NestedText.args = {
   size: "small",
   color: "primary",
   children: "Hey this is some text",

--- a/src/components/Text/Text.styles.ts
+++ b/src/components/Text/Text.styles.ts
@@ -5,6 +5,7 @@ export const TextStyles = {
     fontFamily: ["-apple-system", "BlinkMacSystemFont", "sans-serif"].join(","),
     color: "white",
     letterSpacing: "-0.25px",
+    display: "inline",
   },
 };
 


### PR DESCRIPTION
<img width="216" alt="Screen Shot 2021-09-10 at 11 29 08 AM" src="https://user-images.githubusercontent.com/13020292/132878764-4b799a5d-e785-4f79-9273-c3738ff0d09d.png">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.15--canary.17.7a1224e13521d13ed01d75d4bcd9e7e7cacc73b8.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install citizen-components@1.0.15--canary.17.7a1224e13521d13ed01d75d4bcd9e7e7cacc73b8.0
  # or 
  yarn add citizen-components@1.0.15--canary.17.7a1224e13521d13ed01d75d4bcd9e7e7cacc73b8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
