### PR TITLE
Made callout button less "invisibly wide"

### DIFF
--- a/src/components/CalloutButton/CalloutButton.styles.ts
+++ b/src/components/CalloutButton/CalloutButton.styles.ts
@@ -1,4 +1,8 @@
 export const CalloutButtonStyle = () => ({
+  root: {
+    width: "24px",
+    minWidth: "24px",
+  },
   label: {
     fontFamily: [
       '-apple-system',
@@ -6,8 +10,9 @@ export const CalloutButtonStyle = () => ({
       'sans-serif',
     ].join(','),
     fontSize: "12px",
-    width: "24px",
     height: "24px",
+    width: "24px",
+    padding: "0px 5px",
     backgroundColor: "#262626",
     color: "#8C8C8C",
     borderRadius: "4px",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.16--canary.18.578cd75a45ac307b2034318946ae50882158e44d.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install citizen-components@1.0.16--canary.18.578cd75a45ac307b2034318946ae50882158e44d.0
  # or 
  yarn add citizen-components@1.0.16--canary.18.578cd75a45ac307b2034318946ae50882158e44d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
