### PR TITLE
Add multi label text input

### DIFF
--- a/src/components/MultiLabelTextInput/MultiLabelTextInput.stories.tsx
+++ b/src/components/MultiLabelTextInput/MultiLabelTextInput.stories.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from "react";
+import { Meta } from "@storybook/react/types-6-0";
+import { Story } from "@storybook/react";
+
+import MultiLabelTextInput from "./MultiLabelTextInput";
+
+export default {
+  title: "Components/Inputs/MultiLabelTextInput",
+  component: MultiLabelTextInput,
+} as Meta;
+
+const Template: Story<any> = (args) => {
+  const [inputValue, setInputValue] = useState("");
+  const [options, setOptions] = useState<any>([
+    { number: 12, subArea: "Manhattan" },
+    { number: 25, subArea: "Brooklyn" },
+    { number: 7, subArea: "Bronx" },
+  ]);
+
+  const handleInputChange = (val: string) => {
+    setInputValue(val);
+  };
+  return (
+    <div style={{ width: "332px" }}>
+      <MultiLabelTextInput
+        options={options}
+        handleChange={() => {}}
+        inputValue={inputValue}
+        handleInputChange={handleInputChange}
+        getOptionSelected={(option: any, value: any) => {
+          return option.subArea === value.subArea;
+        }}
+        onDeleteOption={(option: any) => {
+          const indexToRemove = options.findIndex(
+            (opt: any) => opt.subArea === option.subArea
+          );
+          const newOpts = [...options];
+          newOpts.splice(indexToRemove, 1);
+
+          setOptions([...newOpts]);
+        }}
+        chipLabel={(option: any) => (
+          <div style={{ display: "flex" }}>
+            {option.subArea}
+            <div
+              style={{
+                color: "#4da6ff",
+                paddingLeft: "4px",
+              }}
+            >
+              ({option.number})
+            </div>
+          </div>
+        )}
+        inputLabel="Coverage Selection"
+      />
+    </div>
+  );
+};
+
+export const CustomLabels = Template.bind({});

--- a/src/components/MultiLabelTextInput/MultiLabelTextInput.stories.tsx
+++ b/src/components/MultiLabelTextInput/MultiLabelTextInput.stories.tsx
@@ -24,7 +24,6 @@ const Template: Story<any> = (args) => {
     <div style={{ width: "332px" }}>
       <MultiLabelTextInput
         options={options}
-        handleChange={() => {}}
         inputValue={inputValue}
         handleInputChange={handleInputChange}
         getOptionSelected={(option: any, value: any) => {

--- a/src/components/MultiLabelTextInput/MultiLabelTextInput.styles.ts
+++ b/src/components/MultiLabelTextInput/MultiLabelTextInput.styles.ts
@@ -1,0 +1,68 @@
+import { withStyles } from "@material-ui/styles";
+import { Chip, TextField } from "@material-ui/core";
+import { Autocomplete } from "@material-ui/lab";
+
+export const StyledAutocomplete = withStyles({
+  root: {
+    width: "100%",
+    margin: "auto",
+    "& label": {
+      color: "#666666",
+    },
+    "& label.Mui-focused": {
+      color: "#666666",
+    },
+    height: "44px",
+  },
+  inputRoot: {
+    color: "#666666",
+    // Couldnt get to work without !important, MUI overwrites it for some reason
+    padding: "6px 10px 0px 10px !important",
+  },
+  popupIndicator: {
+    display: "none",
+  },
+  clearIndicator: {
+    display: "none",
+  },
+})(Autocomplete);
+
+export const StyledChip = withStyles({
+  root: {
+    backgroundColor: "#1a2633",
+    borderRadius: "4px",
+    color: "white",
+    height: "24px",
+    padding: "4px 0px",
+    marginRight: "4px",
+    marginBottom: "4px",
+  },
+  label: {
+    fontSize: "12px",
+    lineHeight: "16px",
+    textTransform: "capitalize",
+    fontWeight: "bold",
+    display: "flex",
+    textAlign: "center",
+    alignContent: "center",
+  },
+})(Chip);
+
+export const StyledInput = withStyles({
+  root: {
+    padding: "0px !important",
+    color: "white",
+    height: "44px",
+    "& .MuiOutlinedInput-root": {
+      "& fieldset": {
+        borderColor: "#404040",
+      },
+      "&:hover fieldset": {
+        borderColor: "#404040",
+      },
+      "&.Mui-focused fieldset": {
+        borderColor: "#404040",
+      },
+    },
+  },
+})(TextField);

--- a/src/components/MultiLabelTextInput/MultiLabelTextInput.tsx
+++ b/src/components/MultiLabelTextInput/MultiLabelTextInput.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+
+import { Chip, TextField } from "@material-ui/core";
+import { withStyles } from "@material-ui/styles";
+import { Autocomplete } from "@material-ui/lab";
+
+const StyledAutocomplete = withStyles({
+  root: {
+    width: "100%",
+    margin: "auto",
+    "& label": {
+      color: "#666666",
+    },
+    "& label.Mui-focused": {
+      color: "#666666",
+    },
+    height: "44px",
+  },
+  inputRoot: {
+    color: "#666666",
+    // Couldnt get to work without !important, MUI overwrites it for some reason
+    padding: "6px 10px 0px 10px !important",
+  },
+  popupIndicator: {
+    display: "none",
+  },
+  clearIndicator: {
+    display: "none",
+  },
+})(Autocomplete);
+
+const StyledChip = withStyles({
+  root: {
+    backgroundColor: "#1a2633",
+    borderRadius: "4px",
+    color: "white",
+    height: "24px",
+    padding: "4px 0px",
+    marginRight: "4px",
+    marginBottom: "4px",
+  },
+  label: {
+    fontSize: "12px",
+    lineHeight: "16px",
+    textTransform: "capitalize",
+    fontWeight: "bold",
+    display: "flex",
+    textAlign: "center",
+    alignContent: "center",
+  },
+})(Chip);
+
+const StyledInput = withStyles({
+  root: {
+    padding: "0px !important",
+    color: "white",
+    height: "44px",
+    "& .MuiOutlinedInput-root": {
+      "& fieldset": {
+        borderColor: "#404040",
+      },
+      "&:hover fieldset": {
+        borderColor: "#404040",
+      },
+      "&.Mui-focused fieldset": {
+        borderColor: "#404040",
+      },
+    },
+  },
+})(TextField);
+
+interface IProps {
+  options: Array<any>;
+  handleChange: (value: string) => void;
+  inputValue: string;
+  handleInputChange: (value: string) => void;
+  chipLabel: (option: any) => JSX.Element;
+  getOptionSelected: (option: any, value: any) => boolean;
+  onDeleteOption: (option: any) => void;
+  inputLabel: string;
+}
+
+const MultiLabelTextInput = ({
+  options,
+  handleChange,
+  inputValue,
+  handleInputChange,
+  chipLabel,
+  getOptionSelected,
+  onDeleteOption,
+  inputLabel,
+}: IProps) => {
+  return (
+    <StyledAutocomplete
+      multiple
+      id="tags-outlined"
+      options={options}
+      value={options}
+      inputValue={inputValue}
+      open={false}
+      limitTags={2}
+      getOptionSelected={getOptionSelected}
+      filterSelectedOptions
+      renderTags={(value) =>
+        value.map((option: any) => (
+          <StyledChip
+            key={option.subArea}
+            size="small"
+            onDelete={() => onDeleteOption(option)}
+            label={chipLabel(option)}
+          />
+        ))
+      }
+      renderInput={(params) => (
+        <StyledInput
+          {...params}
+          value={inputValue}
+          style={{ height: "44px" }}
+          onChange={(e) => handleInputChange(e.target.value.toLowerCase())}
+          variant="outlined"
+          label={inputLabel}
+          placeholder={
+            options
+              ? "search..."
+              : "search service areas, cities, or regions... "
+          }
+        />
+      )}
+    />
+  );
+};
+
+export default MultiLabelTextInput;

--- a/src/components/MultiLabelTextInput/MultiLabelTextInput.tsx
+++ b/src/components/MultiLabelTextInput/MultiLabelTextInput.tsx
@@ -1,73 +1,10 @@
 import React from "react";
 
-import { Chip, TextField } from "@material-ui/core";
-import { withStyles } from "@material-ui/styles";
-import { Autocomplete } from "@material-ui/lab";
-
-const StyledAutocomplete = withStyles({
-  root: {
-    width: "100%",
-    margin: "auto",
-    "& label": {
-      color: "#666666",
-    },
-    "& label.Mui-focused": {
-      color: "#666666",
-    },
-    height: "44px",
-  },
-  inputRoot: {
-    color: "#666666",
-    // Couldnt get to work without !important, MUI overwrites it for some reason
-    padding: "6px 10px 0px 10px !important",
-  },
-  popupIndicator: {
-    display: "none",
-  },
-  clearIndicator: {
-    display: "none",
-  },
-})(Autocomplete);
-
-const StyledChip = withStyles({
-  root: {
-    backgroundColor: "#1a2633",
-    borderRadius: "4px",
-    color: "white",
-    height: "24px",
-    padding: "4px 0px",
-    marginRight: "4px",
-    marginBottom: "4px",
-  },
-  label: {
-    fontSize: "12px",
-    lineHeight: "16px",
-    textTransform: "capitalize",
-    fontWeight: "bold",
-    display: "flex",
-    textAlign: "center",
-    alignContent: "center",
-  },
-})(Chip);
-
-const StyledInput = withStyles({
-  root: {
-    padding: "0px !important",
-    color: "white",
-    height: "44px",
-    "& .MuiOutlinedInput-root": {
-      "& fieldset": {
-        borderColor: "#404040",
-      },
-      "&:hover fieldset": {
-        borderColor: "#404040",
-      },
-      "&.Mui-focused fieldset": {
-        borderColor: "#404040",
-      },
-    },
-  },
-})(TextField);
+import {
+  StyledAutocomplete,
+  StyledChip,
+  StyledInput,
+} from "./MultiLabelTextInput.styles";
 
 interface IProps {
   options: Array<any>;

--- a/src/components/MultiLabelTextInput/MultiLabelTextInput.tsx
+++ b/src/components/MultiLabelTextInput/MultiLabelTextInput.tsx
@@ -71,7 +71,6 @@ const StyledInput = withStyles({
 
 interface IProps {
   options: Array<any>;
-  handleChange: (value: string) => void;
   inputValue: string;
   handleInputChange: (value: string) => void;
   chipLabel: (option: any) => JSX.Element;
@@ -82,7 +81,6 @@ interface IProps {
 
 const MultiLabelTextInput = ({
   options,
-  handleChange,
   inputValue,
   handleInputChange,
   chipLabel,
@@ -119,11 +117,6 @@ const MultiLabelTextInput = ({
           onChange={(e) => handleInputChange(e.target.value.toLowerCase())}
           variant="outlined"
           label={inputLabel}
-          placeholder={
-            options
-              ? "search..."
-              : "search service areas, cities, or regions... "
-          }
         />
       )}
     />

--- a/src/components/MultiLabelTextInput/index.ts
+++ b/src/components/MultiLabelTextInput/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MultiLabelTextInput";

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,17 @@ import MultilineInput from "./components/MultilineInput";
 import Select from "./components/Select";
 import Text from "./components/Text";
 import Checkbox from "./components/Checkbox";
-import CalloutButton from "./components/CalloutButton"
-export { Button, TextInput, ToggleButton, MultilineInput, Select, Text, CalloutButton, Checkbox };
+import CalloutButton from "./components/CalloutButton";
+import MultiLabelTextInput from "./components/MultiLabelTextInput";
+
+export {
+  Button,
+  TextInput,
+  ToggleButton,
+  MultilineInput,
+  Select,
+  Text,
+  CalloutButton,
+  Checkbox,
+  MultiLabelTextInput,
+};


### PR DESCRIPTION


https://user-images.githubusercontent.com/13020292/133137320-b61dacac-2f68-4bae-9cbf-52103e09edad.mov



<img width="386" alt="Screen Shot 2021-09-13 at 2 08 38 PM" src="https://user-images.githubusercontent.com/13020292/133134909-b07d07af-5f8f-470b-a12e-eec04c12eab5.png">

<img width="404" alt="Screen Shot 2021-09-13 at 2 08 42 PM" src="https://user-images.githubusercontent.com/13020292/133134922-443ce9fb-b487-4fc6-a8eb-a155fc8417d4.png">


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.19--canary.22.756672bdcfde52d0471fc10b52859b79680cdac3.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install citizen-components@1.0.19--canary.22.756672bdcfde52d0471fc10b52859b79680cdac3.0
  # or 
  yarn add citizen-components@1.0.19--canary.22.756672bdcfde52d0471fc10b52859b79680cdac3.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
