### PR TITLE
Tweak buttons to match designs more closely with some variants

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Meta} from "@storybook/react/types-6-0";
-import {Story} from "@storybook/react"
+import { Meta } from "@storybook/react/types-6-0";
+import { Story } from "@storybook/react";
 import Button, { StyledButtonProps } from "./Button";
 
 export default {
@@ -9,21 +9,21 @@ export default {
 } as Meta;
 
 const Template: Story<StyledButtonProps> = (args) => {
-  return (
-    <Button {...args}>
-      {args.children}
-    </Button>
-  )
-}
+  return <Button {...args}>{args.children}</Button>;
+};
 
-export const Active = Template.bind({})
-Active.args = { buttonType: 'active', children: 'Active' }
+export const Active = Template.bind({});
+Active.args = { buttonType: "active", children: "Active", width: "122px" };
 
-export const Submit = Template.bind({})
-Submit.args = { buttonType: 'submit', children: 'Submit' }
+export const Submit = Template.bind({});
+Submit.args = { buttonType: "submit", children: "Submit", width: "122px" };
 
-export const Warning = Template.bind({})
-Warning.args = { buttonType: 'warning', children: 'Warning' }
+export const Warning = Template.bind({});
+Warning.args = { buttonType: "warning", children: "Warning", width: "122px" };
 
-export const Secondary = Template.bind({})
-Secondary.args = { buttonType: 'secondary', children: 'Secondary' }
+export const Secondary = Template.bind({});
+Secondary.args = {
+  buttonType: "secondary",
+  children: "Secondary",
+  width: "122px",
+};

--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -1,29 +1,30 @@
 export const ButtonStyle = () => ({
   root: {
-    borderRadius: "30px",
-    padding: '15px  25px 15px 25px',
+    borderRadius: "20px",
   },
   label: {
-    fontFamily: [
-      '-apple-system',
-      'BlinkMacSystemFont',
-      'sans-serif',
-    ].join(','),
-    fontSize: "13px",
+    fontFamily: ["-apple-system", "BlinkMacSystemFont", "sans-serif"].join(","),
+    fontSize: "12px",
     lineHeight: "16px",
   },
-})
+});
 
-export const PropColors = () => ({
-  colors: (props: {
+export const Customization = () => ({
+  root: (props: {
     backgroundColor?: string;
     textColor?: string;
+    width?: string;
+    height?: string;
+    padding?: string;
   }) => ({
     backgroundColor: props.backgroundColor,
     color: props.textColor,
     "&:hover": {
-      backgroundColor: props.backgroundColor
+      backgroundColor: props.backgroundColor,
     },
     fontWeight: 600,
+    width: props.width,
+    height: props.height,
+    padding: props.padding,
   }),
-})
+});

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,44 +1,70 @@
 import React from "react";
-import MaterialButton from '@material-ui/core/Button';
-import {ButtonProps} from "@material-ui/core/Button";
-import {makeStyles, withStyles} from "@material-ui/core/styles";
-import { ButtonStyle, PropColors } from "./Button.styles"
+import MaterialButton from "@material-ui/core/Button";
+import { ButtonProps } from "@material-ui/core/Button";
+import { makeStyles, withStyles } from "@material-ui/core/styles";
+import { ButtonStyle, Customization } from "./Button.styles";
 
 const ButtonStyled = withStyles(ButtonStyle)(MaterialButton);
 
 export interface StyledButtonProps extends ButtonProps {
   primary?: boolean;
-  buttonType?: 'submit' | 'warning' | 'active' | 'secondary';
-  onClick?: (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ) => void;
+  buttonType?: "submit" | "warning" | "active" | "secondary";
+  width?: string;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 
-const useStyles = makeStyles(PropColors);
+const useStyles = makeStyles(Customization);
 
-export default function Button({ buttonType, onClick, ...props }: StyledButtonProps) {
-  let backgroundColor
-  let textColor
+export default function Button({
+  buttonType,
+  onClick,
+  width,
+  size,
+  ...props
+}: StyledButtonProps) {
+  let backgroundColor;
+  let textColor;
+  let height;
+  let padding;
 
-  if (buttonType === 'submit') {
-    backgroundColor = '#4DA6FF'
-    textColor = 'white'
-  } else if (buttonType === 'warning') {
-    backgroundColor = '#331C1F'
-    textColor = '#CC858D'
-  } else if (buttonType === 'active') {
-    backgroundColor = '#1A2633'
-    textColor = 'white'
-  } else if (buttonType === 'secondary') {
-    backgroundColor = '#666666'
-    textColor = 'white'
+  if (buttonType === "submit") {
+    backgroundColor = "#4DA6FF";
+    textColor = "white";
+  } else if (buttonType === "warning") {
+    backgroundColor = "#331C1F";
+    textColor = "#CC858D";
+  } else if (buttonType === "active") {
+    backgroundColor = "#1A2633";
+    textColor = "white";
+  } else if (buttonType === "secondary") {
+    backgroundColor = "#666666";
+    textColor = "white";
   }
 
-  const classes = useStyles({backgroundColor, textColor});
+  if (size === "small") {
+    height = "24px";
+    padding = "4px 8px";
+  } else {
+    height = "32px";
+    padding = "8px 12px";
+  }
+
+  const classes = useStyles({
+    backgroundColor,
+    textColor,
+    width,
+    height,
+    padding,
+  });
 
   return (
-    <ButtonStyled className={ `${classes.colors}` } onClick={onClick} {...props} style={{textTransform: 'none'}}>
+    <ButtonStyled
+      classes={{ root: classes.root }}
+      onClick={onClick}
+      {...props}
+      style={{ textTransform: "none" }}
+    >
       {props.children}
     </ButtonStyled>
   );
-};
+}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -38,7 +38,7 @@ export default function Button({
     textColor = "white";
   } else if (buttonType === "secondary") {
     backgroundColor = "#666666";
-    textColor = "white";
+    textColor = "#b3b3b3";
   }
 
   if (size === "small") {


### PR DESCRIPTION
<img width="175" alt="Screen Shot 2021-09-23 at 5 08 06 PM" src="https://user-images.githubusercontent.com/13020292/134584328-431ffd06-2e12-4e3e-b5dd-f40ab9599c6c.png">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.30--canary.32.928c16fdf50eaa4fbd9de3946b433d587bdad915.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install citizen-components@1.0.30--canary.32.928c16fdf50eaa4fbd9de3946b433d587bdad915.0
  # or 
  yarn add citizen-components@1.0.30--canary.32.928c16fdf50eaa4fbd9de3946b433d587bdad915.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
