### PR TITLE
Add edited text field color and a disabled text field

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -7,12 +7,12 @@ export const parameters = {
     },
   },
   backgrounds: {
-    default: 'POS',
+    default: "POS",
     values: [
       {
-        name: 'POS',
-        value: '#0E151D'
-      }
+        name: "POS",
+        value: "#0E151D",
+      },
     ],
   },
-}
+};

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -1,26 +1,27 @@
 import React, { useState } from "react";
 import { Meta } from "@storybook/react/types-6-0";
 import { Story } from "@storybook/react";
-import TextInput from "./TextInput";
-import { OutlinedInputProps } from "@material-ui/core/OutlinedInput";
+import TextInput, { TextInputProps } from "./TextInput";
 
 export default {
   title: "Components/Inputs/TextInput",
   component: TextInput,
 } as Meta;
 
-const Template: Story<OutlinedInputProps> = (args) => {
-  const [val, setVal] = useState("");
+const Template: Story<TextInputProps> = (args) => {
+  const [val, setVal] = useState("hey this is a value");
+  const [edited, setEdited] = useState(false);
 
   const onChange = (
     e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
   ) => {
     setVal(e.target.value);
+    setEdited(true);
   };
 
   return (
     <>
-      <TextInput {...args} onChange={onChange} />
+      <TextInput {...args} onChange={onChange} value={val} edited={edited} />
     </>
   );
 };
@@ -34,3 +35,11 @@ Notched.args = {
 
 export const NoNotch = Template.bind({});
 NoNotch.args = { placeholder: "Hey this is an input" };
+
+export const NotchedDisabled = Template.bind({});
+NotchedDisabled.args = {
+  notched: true,
+  label: "This is a label",
+  placeholder: "Hey this is a placeholder",
+  disabled: true,
+};

--- a/src/components/TextInput/TextInput.styles.ts
+++ b/src/components/TextInput/TextInput.styles.ts
@@ -15,6 +15,18 @@ export const baseStyles = {
     fontFamily: ["-apple-system", "BlinkMacSystemFont", "sans-serif"].join(","),
     fontWeight: 500,
   },
+  disabled: {
+    color: "#8c8c8c",
+    "& .MuiOutlinedInput-notchedOutline": {
+      borderColor: "#333333 !important",
+    },
+    "&:hover .MuiOutlinedInput-notchedOutline": {
+      borderColor: "#333333",
+    },
+    "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+      borderColor: "#333333",
+    },
+  },
   input: {
     "&::placeholder": {
       textOverflow: "ellipsis !important",
@@ -24,6 +36,7 @@ export const baseStyles = {
     fontSize: "12px",
     fontFamily: ["-apple-system", "BlinkMacSystemFont", "sans-serif"].join(","),
   },
+
   notchedOutline: {
     "& > legend": {
       visibility: "visible",
@@ -34,3 +47,9 @@ export const baseStyles = {
     },
   },
 };
+
+export const Customization = () => ({
+  input: (props: { textColor?: string }) => ({
+    color: props.textColor,
+  }),
+});

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -2,14 +2,26 @@ import React from "react";
 
 import { OutlinedInput } from "@material-ui/core";
 import { OutlinedInputProps } from "@material-ui/core/OutlinedInput";
-import { withStyles } from "@material-ui/core/styles";
+import { makeStyles, withStyles } from "@material-ui/core/styles";
 
-import { baseStyles } from "./TextInput.styles";
+import { baseStyles, Customization } from "./TextInput.styles";
+
+const useStyles = makeStyles(Customization);
 
 const BaseInput = withStyles(baseStyles)(OutlinedInput);
 
-const TextInput = (props: OutlinedInputProps) => {
-  return <BaseInput {...props} />;
+export interface TextInputProps extends OutlinedInputProps {
+  edited: boolean;
+}
+
+const TextInput = ({ edited, ...props }: TextInputProps) => {
+  const textColor = edited ? "white" : "#8c8c8c";
+
+  const classes = useStyles({
+    textColor,
+  });
+
+  return <BaseInput {...props} classes={{ input: classes.input }} />;
 };
 
 export default TextInput;

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -11,7 +11,7 @@ const useStyles = makeStyles(Customization);
 const BaseInput = withStyles(baseStyles)(OutlinedInput);
 
 export interface TextInputProps extends OutlinedInputProps {
-  edited: boolean;
+  edited?: boolean;
 }
 
 const TextInput = ({ edited, ...props }: TextInputProps) => {


### PR DESCRIPTION

https://user-images.githubusercontent.com/13020292/134591528-576f2bd8-ad4a-4742-80fb-0aaa26c03778.mov


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.31--canary.33.1bc5d2a3f4f5e092086a4e33b2217cec54928cd3.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install citizen-components@1.0.31--canary.33.1bc5d2a3f4f5e092086a4e33b2217cec54928cd3.0
  # or 
  yarn add citizen-components@1.0.31--canary.33.1bc5d2a3f4f5e092086a4e33b2217cec54928cd3.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
