### PR TITLE
Multiline disabled and edited

### DIFF
--- a/src/components/MultilineInput/MultilineInput.stories.tsx
+++ b/src/components/MultilineInput/MultilineInput.stories.tsx
@@ -1,30 +1,45 @@
 import React, { useState } from "react";
 import { Meta } from "@storybook/react/types-6-0";
 import { Story } from "@storybook/react";
-import MultilineInput from "./MultilineInput";
-import { OutlinedInputProps } from "@material-ui/core/OutlinedInput";
+import MultilineInput, { MultilineInputProps } from "./MultilineInput";
 
 export default {
   title: "Components/Inputs/MultilineInput",
   component: MultilineInput,
 } as Meta;
 
-const Template: Story<OutlinedInputProps> = (args) => {
+const Template: Story<MultilineInputProps> = (args) => {
   const [val, setVal] = useState("");
+  const [edited, setEdited] = useState(false);
 
   const onChange = (
     e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
   ) => {
     setVal(e.target.value);
+    setEdited(true);
   };
 
   return (
     <div style={{ width: "200px" }}>
-      <MultilineInput {...args} multiline onChange={onChange} />
+      <MultilineInput
+        {...args}
+        multiline
+        onChange={onChange}
+        value={val}
+        edited={edited}
+      />
       <p>{val}</p>
     </div>
   );
 };
 
 export const Primary = Template.bind({});
-Primary.args = { placeholder: "Update...", rows: 3 };
+Primary.args = { placeholder: "Update...", rows: 3, disabled: false };
+
+export const Edited = Template.bind({});
+Edited.args = {
+  placeholder: "Update...",
+  rows: 3,
+  disabled: false,
+  edited: false,
+};

--- a/src/components/MultilineInput/MultilineInput.styles.ts
+++ b/src/components/MultilineInput/MultilineInput.styles.ts
@@ -48,7 +48,7 @@ export const baseStyles = {
 };
 
 export const Customization = () => ({
-  root: (props: { textColor?: string }) => ({
+  input: (props: { textColor?: string }) => ({
     color: props.textColor,
   }),
 });

--- a/src/components/MultilineInput/MultilineInput.styles.ts
+++ b/src/components/MultilineInput/MultilineInput.styles.ts
@@ -13,6 +13,18 @@ export const baseStyles = {
       borderColor: "#333333",
     },
   },
+  disabled: {
+    color: "#8c8c8c",
+    "& .MuiOutlinedInput-notchedOutline": {
+      borderColor: "#333333 !important",
+    },
+    "&:hover .MuiOutlinedInput-notchedOutline": {
+      borderColor: "#333333",
+    },
+    "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+      borderColor: "#333333",
+    },
+  },
   notchedOutline: {
     "& > legend": {
       visibility: "visible",
@@ -22,7 +34,21 @@ export const baseStyles = {
       color: "#8C8C8C",
     },
   },
+  input: {
+    "&::placeholder": {
+      textOverflow: "ellipsis !important",
+      color: "#8c8c8c",
+      opacity: 100,
+    },
+    fontFamily: ["-apple-system", "BlinkMacSystemFont", "sans-serif"].join(","),
+  },
   multiline: {
     padding: "14px 10px",
   },
 };
+
+export const Customization = () => ({
+  root: (props: { textColor?: string }) => ({
+    color: props.textColor,
+  }),
+});

--- a/src/components/MultilineInput/MultilineInput.tsx
+++ b/src/components/MultilineInput/MultilineInput.tsx
@@ -2,13 +2,21 @@ import React from "react";
 
 import { OutlinedInput } from "@material-ui/core";
 import { OutlinedInputProps } from "@material-ui/core/OutlinedInput";
-import { withStyles } from "@material-ui/core/styles";
+import { withStyles, makeStyles } from "@material-ui/core/styles";
 
-import { baseStyles } from "./MultilineInput.styles";
+import { baseStyles, Customization } from "./MultilineInput.styles";
+
+const useStyles = makeStyles(Customization);
 
 const BaseInput = withStyles(baseStyles)(OutlinedInput);
 
-const MultilineInput = (props: OutlinedInputProps) => {
+export interface MultilineInputProps extends OutlinedInputProps {
+  edited?: boolean;
+}
+
+const MultilineInput = ({ edited, ...props }: MultilineInputProps) => {
+  const textColor = edited ? "white" : "#8c8c8c";
+
   const inputProps = { ...props };
   if (props.rows) {
     inputProps.style = {
@@ -16,7 +24,14 @@ const MultilineInput = (props: OutlinedInputProps) => {
       height: `${36 + 16 * Number(props.rows)}px`,
     };
   }
-  return <BaseInput {...inputProps} multiline />;
+
+  const classes = useStyles({
+    textColor,
+  });
+
+  return (
+    <BaseInput {...inputProps} multiline classes={{ input: classes.root }} />
+  );
 };
 
 export default MultilineInput;

--- a/src/components/MultilineInput/MultilineInput.tsx
+++ b/src/components/MultilineInput/MultilineInput.tsx
@@ -30,7 +30,7 @@ const MultilineInput = ({ edited, ...props }: MultilineInputProps) => {
   });
 
   return (
-    <BaseInput {...inputProps} multiline classes={{ input: classes.root }} />
+    <BaseInput {...inputProps} multiline classes={{ input: classes.input }} />
   );
 };
 


### PR DESCRIPTION
basically the same as the text input but for multiline
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.32--canary.34.195bab7906d51ecf774a6e8ce1b4f70e31df3e9b.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install citizen-components@1.0.32--canary.34.195bab7906d51ecf774a6e8ce1b4f70e31df3e9b.0
  # or 
  yarn add citizen-components@1.0.32--canary.34.195bab7906d51ecf774a6e8ce1b4f70e31df3e9b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
