### PR TITLE
Fix Callout Button width sizing

### DIFF
--- a/src/components/CalloutButton/CalloutButton.module.css
+++ b/src/components/CalloutButton/CalloutButton.module.css
@@ -2,7 +2,7 @@
   font-family: -apple-system, -BlinkMacSystemFont, sans-serif;
   font-size: 12px;
   height: 24px;
-  width: 24px;
+  width: fit-content;
   padding: 0px 4px;
   background-color: #262626;
   color: #8C8C8C;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.51--canary.56.37bf5979fe698d658749436d633242c559b6552a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install citizen-components@1.0.51--canary.56.37bf5979fe698d658749436d633242c559b6552a.0
  # or 
  yarn add citizen-components@1.0.51--canary.56.37bf5979fe698d658749436d633242c559b6552a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
