### PR TITLE
Callout Button Fixed Size

### DIFF
--- a/src/components/CalloutButton/CalloutButton.module.css
+++ b/src/components/CalloutButton/CalloutButton.module.css
@@ -2,7 +2,7 @@
   font-family: -apple-system, -BlinkMacSystemFont, sans-serif;
   font-size: 12px;
   height: 24px;
-  width: fit-content;
+  width: 32px;
   padding: 0px 4px;
   background-color: #262626;
   color: #8C8C8C;


### PR DESCRIPTION
It's causing things to shift in POS because it's not a fixed size.